### PR TITLE
Get module from PSGallery to allow other PSRepositories to exist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,7 @@ runs:
         AZURE_USERNAME: ${{ inputs.azure-username }}
         AZURE_PASSWORD: ${{ inputs.azure-password }}
       run: |
-        Install-Module -Name AzureCodeSigning -RequiredVersion 0.2.15 -Force
+        Install-Module -Name AzureCodeSigning -RequiredVersion 0.2.15 -Force -Repository PSGallery
 
         $params = @{}
 


### PR DESCRIPTION
Came across an issue when there's more than 1 PSrepository available in which the install-module fails