### PR TITLE
Remove correlation id from inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,6 @@ code-signing-account-name: my-account-name
 
 # The Certificate Profile name.
 certificate-profile-name: my-profile-name
-
-# An opaque string value that you can provide to correlate sign requests with your own workflows such as build identifiers or machine names.
-correlation-id: 32C50B44-D8D0-457A-B0FD-9D8220DE91C7
 ```
 
 ### File Specification

--- a/action.yml
+++ b/action.yml
@@ -37,10 +37,6 @@ inputs:
   certificate-profile-name:
     description: The Certificate Profile name.
     required: true
-  correlation-id:
-    description: An opaque string value that you can provide to correlate sign requests with your own
-                 workflows such as build identifiers or machine names.
-    required: false
   files-folder:
     description: The folder containing files to be signed. Can be combined with the file-catalog input.
     required: false
@@ -198,11 +194,6 @@ runs:
         $certificateProfileName = "${{ inputs.certificate-profile-name }}"
         if (-Not [string]::IsNullOrWhiteSpace($certificateProfileName)) {
           $params["CertificateProfileName"] = $certificateProfileName
-        }
-
-        $correlationId = "${{ inputs.correlation-id }}"
-        if (-Not [string]::IsNullOrWhiteSpace($correlationId)) {
-          $params["CorrelationId"] = $correlationId
         }
 
         $filesFolder = "${{ inputs.files-folder }}"


### PR DESCRIPTION
This option is no longer supported by the PowerShell module.