### PR TITLE
Update ACS module to 0.2.24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
         AZURE_USERNAME: ${{ inputs.azure-username }}
         AZURE_PASSWORD: ${{ inputs.azure-password }}
       run: |
-        Install-Module -Name AzureCodeSigning -RequiredVersion 0.2.15 -Force -Repository PSGallery
+        Install-Module -Name AzureCodeSigning -RequiredVersion 0.2.24 -Force -Repository PSGallery
 
         $params = @{}
 


### PR DESCRIPTION
This bump fixes an exception that occurs when we filter files without a file extension.