### PR TITLE
Add support for batch sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,14 +215,14 @@ pkcs7-oid: 1.3.6.1.5.5.7.3.3
 enhanced-key-usage: 1.3.6.1.5.5.7.3.3
 ```
 
-### Timeout
+### Miscellaneous
 ```yaml
 # The number of seconds that the Azure Code Signing service will wait for all files to be signed before it exits. The default value is 300 seconds.
 timeout: 600
-```
 
-## Release Notes
-<!-- to be added -->
+# The summed length of file paths that can be signed with each signtool call. This parameter should only be relevant if you are signing a large number of files. Increasing the value may result in performance gains at the risk of potentially hitting your system's maximum command length limit. The minimum value is 0 and the maximum value is 30000. A value of 0 means that every file will be signed with an individual call to signtool.
+batch-size: 10000
+```
 
 ## Contributing
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,13 @@ inputs:
     description: The number of seconds that the Azure Code Signing service will wait for all files
                  to be signed before it exits. The default value is 300 seconds.
     required: false
+  batch-size:
+    description: The summed length of file paths that can be signed with each signtool call. This parameter
+                 should only be relevant if you are signing a large number of files. Increasing the value
+                 may result in performance gains at the risk of potentially hitting your system's maximum
+                 command length limit. The minimum value is 0 and the maximum value is 30000. A value of
+                 0 means that every file will be signed with an individual call to signtool.
+    required: false
 
 runs:
   using: 'composite'
@@ -177,7 +184,7 @@ runs:
         AZURE_USERNAME: ${{ inputs.azure-username }}
         AZURE_PASSWORD: ${{ inputs.azure-password }}
       run: |
-        Install-Module -Name AzureCodeSigning -RequiredVersion 0.2.25 -Force -Repository PSGallery
+        Install-Module -Name AzureCodeSigning -RequiredVersion 0.2.26 -Force -Repository PSGallery
 
         $params = @{}
 
@@ -344,6 +351,11 @@ runs:
         $timeout = "${{ inputs.timeout }}"
         if (-Not [string]::IsNullOrWhiteSpace($timeout)) {
           $params["Timeout"] = [System.Convert]::ToInt32($timeout)
+        }
+
+        $batchSize = "${{ inputs.batch-size }}"
+        if (-Not [string]::IsNullOrWhiteSpace($batchSize)) {
+          $params["BatchSize"] = [System.Convert]::ToInt32($batchSize)
         }
 
         Invoke-AzureCodeSigning @params


### PR DESCRIPTION
There is some max command length when running the Start-Process command. It is possible for users to hit this limit when they are signing hundred of files at once. This is an issue as we currently only run signtool once.

This PR adds support for dividing the files into batches based on the summed length of characters of all the files being signed. I chose a default BatchSize of 10k just to be safe and to allow users to go up if they want as the maximum command length can vary on different systems (but is usually ~30k).

Interestingly enough, batching the files to just a few signtool calls does result in performance improvements (as opposed to batch size of 0 where each file is signed by 1 call to signtool):

BatchSize 0: 17.5 min
BatchSize 10k: 8 min

Closes #20