### PR TITLE
Update ACS package to 0.3.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # see https://help.github.com/articles/about-codeowners
 
 # Default owner
-* @azure/vscx-tools-platform
+* @azure/vscx-tools-platform @azure/vscx-tools-ui

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: https://eus2.codesigning.azure.net/
+          endpoint: https://eus.codesigning.azure.net/
           code-signing-account-name: vscx-codesigning
           certificate-profile-name: vscx-certificate-profile
           files-folder: ${{ github.workspace }}\App\App\bin\Release\net6.0-windows
@@ -109,7 +109,7 @@ exclude-interactive-browser-credential: true
 ### Account Details
 ```yaml
 # The Code Signing Account endpoint. The URI value must have a URI that aligns to the region your Code Signing Account and Certificate Profile you are specifying were created in during the setup of these resources.
-endpoint: https://eus2.codesigning.azure.net/
+endpoint: https://eus.codesigning.azure.net/
 
 # The Code Signing Account name.
 code-signing-account-name: my-account-name
@@ -230,7 +230,7 @@ batch-size: 10000
 There is currently a known issue with the WUS region where ~10% of signing requests will be very slow (up to 100 seconds to sign a single file). This may cause significant slow downs and possibly timeout failures during runs. It is suggested to use the EUS region when possible:
 
 ```yaml
-endpoint: https://eus2.codesigning.azure.net/
+endpoint: https://eus.codesigning.azure.net/
 ```
 
 The Azure Code Signing team is currently working with Azure to solve this problem.

--- a/action.yml
+++ b/action.yml
@@ -164,16 +164,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Remove lock on dotnet.exe
-      run: |
-        try { dotnet build-server shutdown } catch {}
-      shell: pwsh
-
-    - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 6.0.x
-
     - name: Invoke signing
       env:
         AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
@@ -184,7 +174,7 @@ runs:
         AZURE_USERNAME: ${{ inputs.azure-username }}
         AZURE_PASSWORD: ${{ inputs.azure-password }}
       run: |
-        Install-Module -Name AzureCodeSigning -RequiredVersion 0.2.26 -Force -Repository PSGallery
+        Install-Module -Name AzureCodeSigning -RequiredVersion 0.3.0 -Force -Repository PSGallery
 
         $params = @{}
 


### PR DESCRIPTION
- Update ACS package to 0.3.0.
  - This update brings support for .NET runtime version roll forwarding for the ACS dlib so that we don't need to install a very specific version of the .NET runtime.
- Update docs to describe best practices in relation to authentication and server selection.
- Remove .NET runtime installation as the 2019 and 2022 images already have the necessary .NET runtime installed.
- Update CODEOWNERS file to include VSCX UI team.

Closes #21