### PR TITLE
Prepare repo for archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> We're excited to announce that Azure Code Signing has undergone a rebranding and is now known as Trusted Signing. As part of this transition, we're archived the existing repository in favor of [Azure/trusted-signing-action](https://github.com/azure/trusted-signing-action). Please migrate to the new [Trusted Signing Action](https://github.com/marketplace/actions/trusted-signing) as soon as possible. All future bug fixes and enhancements will be exclusively released for the new Action. You will have 90 days to migrate at which point the old repository will be deleted.
+> We're excited to announce that Azure Code Signing has undergone a rebranding and is now known as Trusted Signing. As part of this transition, we're deprecating the existing Action in favor of [Azure/trusted-signing-action](https://github.com/azure/trusted-signing-action). Please migrate to the new [Trusted Signing Action](https://github.com/marketplace/actions/trusted-signing) as soon as possible. All future bug fixes and enhancements will be exclusively released for the new Action. You will have 90 days to migrate at which point the old repository will be deleted.
 > - **April 1st, 2024**: Archival
 > - **June 30th, 2024**: Deletion
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> We're excited to announce that Azure Code Signing has undergone a rebranding and is now known as Trusted Signing. As part of this transition, we're archived the existing repository in favor of [Azure/trusted-signing-action](https://github.com/azure/trusted-signing-action). Please migrate to the new [Trusted Signing Action](https://github.com/marketplace/actions/trusted-signing) as soon as possible. All future bug fixes and enhancements will be exclusively released for the new Action. You will have 90 days to migrate at which point the old repository will be deleted.
+> - **April 1st, 2024**: Archival
+> - **June 30th, 2024**: Deletion
+
 # Azure Code Signing
 The Azure Code Signing Action allows you to digitally sign your files using an Azure Code Signing certificate during a GitHub Actions run.
 

--- a/action.yml
+++ b/action.yml
@@ -167,6 +167,7 @@ runs:
     - name: New action warning
       run: |
         Write-Warning "This Action is deprecated and will be deleted on June 30th, 2024. Please migrate to the new Trusted Signing Action (https://github.com/azure/trusted-signing-action) as soon as possible. All future bug fixes and enhancements will be exclusively released for the new Action."
+      shell: pwsh
   
     - name: Invoke signing
       env:

--- a/action.yml
+++ b/action.yml
@@ -164,6 +164,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: New action warning
+      run: |
+        Write-Warning "This Action is deprecated and will be deleted on June 30th, 2024. Please migrate to the new Trusted Signing Action (https://github.com/azure/trusted-signing-action) as soon as possible. All future bug fixes and enhancements will be exclusively released for the new Action."
+  
     - name: Invoke signing
       env:
         AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}


### PR DESCRIPTION
This repo will be archived April 1st in favor of our new repo at https://github.com/azure/trusted-signing-action.